### PR TITLE
Moved web-console into test group

### DIFF
--- a/lib/bretelline/templates/solidus_gemfile.erb
+++ b/lib/bretelline/templates/solidus_gemfile.erb
@@ -39,6 +39,9 @@ group :development, :test do
   gem 'dev_tools', github: 'nebulab/dev_tools'
   gem 'listen', '~> 3.0.5'
   gem 'rspec-rails', '~> 3.6.0'
+end
+
+group :development do
   gem 'web-console', '>= 3.3.0'
 end
 


### PR DESCRIPTION
Get thie error when run specs:

---
Web Console is activated in the test environment. This is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it in the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
---